### PR TITLE
Added comments to LeaderElector recipe; made changes to use RTT.

### DIFF
--- a/Go/leader_elector.go
+++ b/Go/leader_elector.go
@@ -22,58 +22,169 @@ import (
 	"github.com/coreos/etcd/client"
 )
 
+// LEADER-ELECTOR RECIPE
+//
+// This simple recipe can be used to elect a leader among a set of processes.
+// The following is how the recipe operates:
+//   - All the processes that participate in the elecion decide on a key path
+//     to use for the election.
+//   - As a first step every process tries to create the key with PrevExist
+//     flag set to FALSE. The value that every process tries to set describes
+//     its identity (IP address, host name etc...). Only one among all would
+//     succeed in creating the key and that process would declare itself as the
+//     leader. The leader will also start renewing the TTL of its key.
+//   - All other processes will transition into a wait state wherein they start
+//     observing the key. If the key gets either deleted or expired then all
+//     the processes in the wait state attempt to become the leader.
+
+// A descriptor structure for the leader election operation.
 type LeaderElector struct {
-	ec      *EtcdConnector
+	// Pointer to the etcd connection descriptor.
+	ec *EtcdConnector
+
+	// Key path that will be used to implement leader election.
 	keyPath string
-	value   string
-	obsvr   *Observer
-	ctx     context.Context
-	cancel  context.CancelFunc
+
+	// Value to be stored in the above key if the caller becomes leader.
+	value string
+
+	// An observer object to track the liveliness of the leader.
+	obsvr *Observer
+
+	// A time interval to be set as TTL value for @keyPath.
+	ttl time.Duration
+
+	// A time interval at which the TTL needs to be renewed.
+	ttlRenew time.Duration
+
+	// Context instance to handle cancellation.
+	ctx context.Context
+
+	// Function to call to initiate cancellation.
+	cancel context.CancelFunc
 }
 
+// A type to describe the status of the leader election operation.
+type LeaderElectorStatus int32
+
+const (
+	// Indicates that the caller has become the leader.
+	LEStatusLeader LeaderElectorStatus = iota
+
+	// Indicates that the caller has lost leaderhip.
+	LEStatusFollower
+
+	// Indicates that the state is unknown. Will be used when init fails.
+	LEStatusUnknown
+)
+
+// A structure that will be sent back to the caller to notify if the caller
+// has acquired or lost leadership. On success, @err will be nil.
 type ElectionResponse struct {
-	err error
+	Status LeaderElectorStatus
+	Err    error
 }
 
 const LE_SLEEP_INTERVAL = 5 * time.Second
 
-func (ec *EtcdConnector) NewLeaderElector(key, val string) *LeaderElector {
+// Description:
+//     A constructor method used to instantiate the leader election operation.
+//
+// Parameters:
+//     @key - key path that will be used as a lock for leader election.
+//     @val - Value that will be stored in the key.
+//
+// Return value:
+//     1. A pointer to a LeaderElector structure.
+func (ec *EtcdConnector) NewLeaderElector(key, val string, interval time.Duration) *LeaderElector {
+	var ttl, ttlRenew time.Duration
+
+	if interval == 0 {
+		ttl = TTL_VAL
+		ttlRenew = TTL_REFRESH_TIMEOUT
+	} else {
+		ttl = interval
+
+		// If the interval specified is less than the RTT required to reach the
+		// etcd servers then set ttl to RTT + interval and the ttl refresh time
+		// to the original interval passed in.
+		if ttl <= ec.serverRTT {
+			ttlRenew = ttl
+			ttl += ec.serverRTT
+		} else {
+			// Else set the ttl refresh time to ttl - RTT.
+			ttlRenew = ttl - ec.serverRTT
+		}
+	}
+
 	return &LeaderElector{
-		ec:      ec,
-		keyPath: key,
-		value:   val,
-		obsvr:   ec.NewObserver(key),
-		ctx:     nil,
-		cancel:  nil,
+		ec:       ec,
+		keyPath:  key,
+		value:    val,
+		obsvr:    ec.NewObserver(key),
+		ttl:      ttl,
+		ttlRenew: ttlRenew,
+		ctx:      nil,
+		cancel:   nil,
 	}
 }
 
+// Description:
+//     A routine that attempts to acquire leadership by trying to create
+//     @keyPath with PrevExist flag set to false.
+//
+// Parameters:
+//     None
+//
+// Return values:
+//     1. An etcd Response structure on success, nil otherwise.
+//     2. An error object on failure, nil otherwise.
 func (le *LeaderElector) acquireLeadership() (*client.Response, error) {
 	opts := &client.SetOptions{PrevExist: client.PrevNoExist, TTL: TTL_VAL}
 	return le.ec.Set(le.ctx, le.keyPath, le.value, opts)
 }
 
+// Description:
+//     A routine that waits to acquire leadership. We would get here only when
+//     the attempt to acquire leadership fails. This routine uses an Observer to
+//     lookout for changes to @keyPath. If the Observer indicates that @keyPath
+//     got "set" or "update" then the routine continues to wait. But if the
+//     Observer indicates that @keyPath got "expired" or "delete" then the
+//     routine stops the Observer and returns back to caller.
+//
+// Parameters:
+//     @waitIndex - The etcd index after which the changes will be monitored.
+//
+// Return value:
+//     1. An etcd Response structure on success, nil otherwise.
+//     2. An error object on failure, nil otherwise.
 func (le *LeaderElector) waitForLeadership(waitIndex uint64) (*client.Response, error) {
 	var resp *client.Response = nil
 	var err error = nil
 
-	wData, err := le.obsvr.Start(waitIndex, false)
+	// Start the observer on @keyPath.
+	oResp, err := le.obsvr.Start(waitIndex, false)
 	if err != nil {
 		return nil, err
 	}
 
-	for d := range wData {
-		if d.err != nil {
+	for o := range oResp {
+		// If any error is seen then stop the Observer and return back.
+		if o.Err != nil {
 			le.obsvr.Stop()
-			err = d.err
+			err = o.Err
 			break
 		} else {
-			if d.Response.Action == "update" || d.Response.Action == "set" {
-				waitIndex = d.Response.Node.ModifiedIndex
+			// If the response is "update" or "set", continue with the observation.
+			if o.Response.Action == "update" || o.Response.Action == "set" {
+				waitIndex = o.Response.Node.ModifiedIndex
 				continue
-			} else if d.Response.Action == "expire" || d.Response.Action == "delete" {
+			} else if o.Response.Action == "expire" || o.Response.Action == "delete" {
+				// If the response is "expired" or "delete" then stop the Observer
+				// and return back to the caller so that the caller can attempt to
+				// become a leader.
 				le.obsvr.Stop()
-				resp = d.Response
+				resp = o.Response
 				break
 			}
 		}
@@ -82,18 +193,37 @@ func (le *LeaderElector) waitForLeadership(waitIndex uint64) (*client.Response, 
 	return resp, err
 }
 
+// Description:
+//     A routine to start the leader election. As a first step the routine tries
+//     to become the leader by creating @keyPath atomically. If create operation
+//     succeeds then the routine transitions itself into RENEW state where it
+//     periodically renews the TTL value of @keyPath. If crete operation fails,
+//     then the routine transitions into WAIT state where it'll start an
+//     Observer on @keyPath. If @keyPath gets deleted or expired then the process
+//     is started from the first step.
+//
+// Parameters:
+//     None
+// Return value:
+//     1. A channel on which ElectionResponse will be notified.
 func (le *LeaderElector) Start() <-chan ElectionResponse {
 	var waitIndex uint64 = 0
 
+	// Create a channel that carries ElectionResponse objects.
 	out := make(chan ElectionResponse, 2)
 
+	// The following channels are used to run the leader election
+	// state machine.
 	await := make(chan bool, 2)
 	renew := make(chan bool, 2)
 
+	// Setup a context with cancellation capability. This will be used to stop
+	// the leader election operation.
 	le.ctx, le.cancel = context.WithCancel(context.Background())
 	if le.ctx == nil || le.cancel == nil {
 		out <- ElectionResponse{
-			err: errors.New("Couldn't instantiate context/cancel objects"),
+			Status: LEStatusUnknown,
+			Err:    errors.New("Couldn't instantiate context/cancel objects"),
 		}
 		close(out)
 		return out
@@ -103,35 +233,62 @@ func (le *LeaderElector) Start() <-chan ElectionResponse {
 		for {
 			select {
 			case <-le.ctx.Done():
+				// This means that the Stop on LeaderElector has been called.
+				// So stop the Observer, close the outward channel ans return.
 				le.obsvr.Stop()
 				close(out)
 				return
 			case <-await:
+				// Lost the race to get elected, so wait for leadership.
 				resp, err := le.waitForLeadership(waitIndex)
 				if err != nil {
+					// If an error occurs during the wait informt the caller,
+					// sleep for a while and attempt to acquire leadership again.
+					out <- ElectionResponse{Status: LEStatusFollower, Err: err}
 					time.Sleep(LE_SLEEP_INTERVAL)
 				} else if resp != nil {
+					// If woken up for the right reason then remember the
+					// ModifiedIndex and attemp to acquire leadership again. The
+					// ModifiedIndex can be used as the waitIndex if the attempt
+					// fails.
 					waitIndex = resp.Node.ModifiedIndex
 				}
 			case <-renew:
-				errChan := le.ec.RenewTTL(le.ctx, le.keyPath, le.value, TTL_VAL, TTL_REFRESH_TIMEOUT)
+				// We get here if the attempt to acquire leadership was successful.
+				// Now renew the TTL at regular intervals to retain the leadership
+				// until the caller relinquishes leadership.
+				errChan := le.ec.RenewTTL(le.ctx, le.keyPath, le.value, le.ttl, le.ttlRenew)
 				for e := range errChan {
-					out <- ElectionResponse{err: e}
+					// If any error occurred while renewing the TTl then it must
+					// be catastrophic. Inform the caller about the issue, sleep
+					// for a while and attempt to acquire leadership.
+					out <- ElectionResponse{Status: LEStatusFollower, Err: e}
 					time.Sleep(LE_SLEEP_INTERVAL)
 					break
 				}
 			default:
+				// By default an attempt will be made acquire leadership. Once
+				// an attempt fails we fallback into WAIT state.
 				_, err := le.acquireLeadership()
 				if err != nil {
 					errObj, ok := err.(client.Error)
+					// If @keyPath is already present then someone else succeeded.
+					// SO transition into WAIT state.
 					if ok == true && errObj.Code == client.ErrorCodeNodeExist {
 						await <- true
 					} else {
+						// An other error means that something catastrophic has
+						// happened. So inform the caller, sleep for a while and
+						// attempt to become leader again.
+						out <- ElectionResponse{Status: LEStatusFollower, Err: err}
 						time.Sleep(LE_SLEEP_INTERVAL)
 					}
 				} else {
+					// If you acquire the leadership then transition into RENEW state.
 					renew <- true
-					out <- ElectionResponse{err: nil}
+
+					// Inform the caller that the leadership has been acquired.
+					out <- ElectionResponse{Status: LEStatusLeader, Err: nil}
 				}
 			}
 		}
@@ -140,6 +297,14 @@ func (le *LeaderElector) Start() <-chan ElectionResponse {
 	return out
 }
 
+// Description:
+//     A routine that stops the leader election operation.
+//
+// Parameters:
+//     None
+//
+// Return value:
+//     None
 func (le *LeaderElector) Stop() {
 	if le.cancel != nil {
 		le.cancel()

--- a/Go/observer.go
+++ b/Go/observer.go
@@ -50,14 +50,14 @@ type Observer struct {
 	cancel context.CancelFunc
 }
 
-// A wrapper structure that will be sent back to user as a response whenever
+// A wrapper structure that will be sent back to caller as a response whenever
 // a watch triggers or an error occurs.
 type ObserverResponse struct {
 	// An etcd response object received when a watch triggers.
 	Response *client.Response
 
 	// An error object, if any.
-	err error
+	Err error
 }
 
 // Description:
@@ -68,7 +68,7 @@ type ObserverResponse struct {
 //            directory or a key.
 //
 // Return value:
-//     @obsvr - A pointer to an Observer structure.
+//     1. A pointer to an Observer structure.
 func (ec *EtcdConnector) NewObserver(key string) *Observer {
 	obsvr := &Observer{
 		ec:     ec,
@@ -91,8 +91,8 @@ func (ec *EtcdConnector) NewObserver(key string) *Observer {
 //                  directory structure.
 //
 // Return values:
-//     @resp - A channel object on which responses will be sent.
-//     @err  - Error info, if any while starting the operation, will be returned.
+//     1. A channel on which responses will be sent.
+//     2. Error info, if any while starting the operation, will be returned.
 func (o *Observer) Start(waitIndex uint64, recursive bool) (<-chan ObserverResponse, error) {
 	// Create an outward channel on which responses will be sent.
 	resp := make(chan ObserverResponse)
@@ -129,12 +129,12 @@ func (o *Observer) Start(waitIndex uint64, recursive bool) (<-chan ObserverRespo
 					// On any other error send the information back to caller. The
 					// onus is on the caller to determine the action (can stop the
 					// observation if the error is catastrophic).
-					resp <- ObserverResponse{Response: nil, err: e}
+					resp <- ObserverResponse{Response: nil, Err: e}
 				}
 			} else {
 				// If indeed there is any change detected, send the etcd Response
 				// back to the caller.
-				resp <- ObserverResponse{Response: r, err: nil}
+				resp <- ObserverResponse{Response: r, Err: nil}
 			}
 		}
 	}()

--- a/Go/service_tracker.go
+++ b/Go/service_tracker.go
@@ -61,7 +61,7 @@ type TrackerData struct {
 	Pairs []Pair
 
 	// Error information, if any.
-	err error
+	Err error
 }
 
 // Description:
@@ -72,7 +72,7 @@ type TrackerData struct {
 //             be tracked.
 //
 // Return value:
-//     @st - A pointer to the ServiceTracker instance.
+//     1. A pointer to the ServiceTracker instance.
 func (ec *EtcdConnector) NewServiceTracker(path string) *ServiceTracker {
 	st := &ServiceTracker{
 		ec:          ec,
@@ -93,7 +93,7 @@ func (ec *EtcdConnector) NewServiceTracker(path string) *ServiceTracker {
 //     None
 //
 // Return value:
-//
+//     1. A channel on which TrackerData will be notified.
 func (st *ServiceTracker) Start() <-chan TrackerData {
 	// Create an outward channel on which service tracker info will be sent.
 	tracker := make(chan TrackerData, 2)
@@ -101,7 +101,7 @@ func (st *ServiceTracker) Start() <-chan TrackerData {
 	// Start the Observer.
 	obResp, err := st.obsvr.Start(0, true)
 	if err != nil {
-		tracker <- TrackerData{Pairs: nil, err: err}
+		tracker <- TrackerData{Pairs: nil, Err: err}
 		close(tracker)
 		return tracker
 	}
@@ -117,8 +117,8 @@ func (st *ServiceTracker) Start() <-chan TrackerData {
 
 			// If any error, report it back to the caller. Rely on the caller
 			// to handle the error appropriately.
-			if or.err != nil {
-				tracker <- TrackerData{Pairs: nil, err: or.err}
+			if or.Err != nil {
+				tracker <- TrackerData{Pairs: nil, Err: or.Err}
 				continue
 			}
 
@@ -127,7 +127,7 @@ func (st *ServiceTracker) Start() <-chan TrackerData {
 			// Get the latest contents of @servicePath directory.
 			r, e := st.ec.Get(context.Background(), st.servicePath, opts)
 			if e != nil {
-				tracker <- TrackerData{Pairs: nil, err: e}
+				tracker <- TrackerData{Pairs: nil, Err: e}
 				continue
 			}
 
@@ -156,7 +156,7 @@ func (st *ServiceTracker) Start() <-chan TrackerData {
 
 			// if anything has changed then send the new pairs to the caller.
 			if updated == true {
-				tracker <- TrackerData{Pairs: curKeyVals, err: nil}
+				tracker <- TrackerData{Pairs: curKeyVals, Err: nil}
 			}
 		}
 


### PR DESCRIPTION
The following are the changes made:
[1] Added comments to the leader elector recipe.
[2] Modified leader elector recipe to return back LeaderElectorStatus
    object to indicate success or failure.
[3] Made changes to EphemeralKey and LeaderElector recipes to account
    for RTT while setting the renewal timers. The logic to calculate
    the RTT is yet to be implemented.
