### PR TITLE
Improved the logic used to track changes in service instances.

### DIFF
--- a/Go/service_tracker.go
+++ b/Go/service_tracker.go
@@ -14,12 +14,7 @@
 
 package etcd_recipes
 
-import (
-	"sync"
-
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
-	"github.com/coreos/etcd/client"
-)
+import "sync"
 
 // SERVICE-TRACKER RECIPE
 //
@@ -33,13 +28,34 @@ import (
 //     can provide details of the instance like IP address/port number etc...
 //   - The interested parties will instantiate a ServiceTracker recipe which
 //     observes the well known path to identify the instances that make up the
-//     service in question. The ServiceTracker recipe makes use of the Observer
-//     recipe to track changes.
+//     service in question. ServiceTracker makes use of the Observer recipe to
+//     track changes.
 //   - The ServiceTracker notifies the caller of any change in the directory by
-//     sending a list of all the instances that are present under the directory.
+//     sending a map of all the instances that are present under the directory.
+
+// ServiceTracker interface to be used by the users of this recipe.
+type ServiceTracker interface {
+	// Start tracking the instances that form a given service. A channel shall
+	// be returned on which the details about the service instances will be sent.
+	Start() (<-chan ServiceData, error)
+
+	// Stop tracking for changes.
+	Stop()
+}
+
+// A structure that will be sent back to the caller whenever a change
+// is observed under @servicePath.
+type ServiceData struct {
+	// A map of active services with service name as key and its content
+	// as value.
+	Services map[string]string
+
+	// Error information, if any.
+	Err error
+}
 
 // A descriptor structure for the service tracking operation.
-type ServiceTracker struct {
+type tracker struct {
 	// Pointer to the etcd connection descriptor.
 	ec *EtcdConnector
 
@@ -53,24 +69,8 @@ type ServiceTracker struct {
 	wg *sync.WaitGroup
 }
 
-// A structure that describes a key-value pair.
-type Pair struct {
-	Key   string
-	Value string
-}
-
-// A structure that will be sent back to the caller whenever a change
-// is observed under @servicePath.
-type TrackerData struct {
-	// An array of all active service instances represented as key-value pairs.
-	Pairs []Pair
-
-	// Error information, if any.
-	Err error
-}
-
 // Description:
-//     A constructor routine to instantiate a service tracking operation.
+//     A constructor routine to instantiate a service tracker.
 //
 // Parameters:
 //     @path - A path in the etcd namespace under which the instances will
@@ -78,47 +78,48 @@ type TrackerData struct {
 //
 // Return value:
 //     1. A pointer to the ServiceTracker instance.
-func (ec *EtcdConnector) NewServiceTracker(path string) *ServiceTracker {
-	st := &ServiceTracker{
+func (ec *EtcdConnector) NewServiceTracker(path string) ServiceTracker {
+	t := &tracker{
 		ec:          ec,
 		servicePath: path,
 		obsvr:       ec.NewObserver(path),
 		wg:          &sync.WaitGroup{},
 	}
-	return st
+	return t
 }
 
 // Description:
 //     A routine to start the service tracking operation. This routine starts
 //     an Observer on @servicePath and waits to hear from the Observer about
-//     changes. If any change is seen then it compares the current array of
-//     Pairs with a cached version. If any difference is seen at all then it
-//     posts the current Pairs on the outward channel.
+//     changes in the form of etcd Response object. Based on the change described
+//     by the "Action" field in the Response object the map of services will be
+//     updated appropriately and caller will be notified about the change via
+//     the outward channel.
 //
 // Parameters:
 //     None
 //
 // Return value:
-//     1. A channel on which TrackerData will be notified.
-func (st *ServiceTracker) Start() (<-chan TrackerData, error) {
-	// Create an outward channel on which service tracker info will be sent.
-	tracker := make(chan TrackerData, 2)
+//     1. A channel on which ServiceData will be notified.
+//     2. An error object describing any errors seen during instantiation.
+func (t *tracker) Start() (<-chan ServiceData, error) {
+	// Create an outward buffered channel on which service instance changes
+	// will be notified to the caller.
+	tracker := make(chan ServiceData, 2)
 
 	// Start the Observer.
-	obResp, err := st.obsvr.Start(0, true)
+	obResp, err := t.obsvr.Start(0, true)
 	if err != nil {
 		close(tracker)
 		return nil, err
 	}
 
-	var curKeyVals []Pair
-	opts := &client.GetOptions{Sort: true, Recursive: true}
-
 	// Account for the go-routine in WaitGroup.
-	st.wg.Add(1)
+	t.wg.Add(1)
 
 	// Observe the changes in a go routine.
 	go func() {
+		services := make(map[string]string)
 		for or := range obResp {
 			// For every trigger check if anything has changed.
 			updated := false
@@ -126,67 +127,61 @@ func (st *ServiceTracker) Start() (<-chan TrackerData, error) {
 			// If any error, report it back to the caller. Rely on the caller
 			// to handle the error appropriately.
 			if or.Err != nil {
-				tracker <- TrackerData{Pairs: nil, Err: or.Err}
+				tracker <- ServiceData{Services: nil, Err: or.Err}
 				continue
 			}
 
-			var newKeyVals []Pair
+			resp := or.Response
 
-			// Get the latest contents of @servicePath directory.
-			r, e := st.ec.Get(context.Background(), st.servicePath, opts)
-			if e != nil {
-				tracker <- TrackerData{Pairs: nil, Err: e}
-				continue
-			}
-
-			// Construct the new key-value pairs found under @servicePath
-			for i := 0; i < len(r.Node.Nodes); i++ {
-				newKeyVals = append(newKeyVals, Pair{
-					Key:   r.Node.Nodes[i].Key,
-					Value: r.Node.Nodes[i].Value,
-				})
-			}
-
-			// Perform a diff.
-			if curKeyVals == nil || len(curKeyVals) != len(newKeyVals) {
-				curKeyVals = newKeyVals
+			if resp.Action == "create" {
+				// If the Action is "create" then a new service instance has
+				// appeared under @servicePath. So, add the new entry to the
+				// @services map.
+				services[resp.Node.Key] = resp.Node.Value
 				updated = true
-			} else {
-				for i := 0; i < len(newKeyVals); i++ {
-					if curKeyVals[i].Key != newKeyVals[i].Key ||
-						curKeyVals[i].Value != newKeyVals[i].Value {
-						curKeyVals = newKeyVals
-						updated = true
-						break
-					}
+			} else if resp.Action == "update" {
+				// If the Action is "update" then see if the contents of the
+				// service instance has changed. If so, update the local services
+				// map. The check is needed as the current etcd version wakes
+				// up the watcher even if the TTL on a key is updated.
+				if services[resp.Node.Key] != resp.Node.Value {
+					services[resp.Node.Key] = resp.Node.Value
+					updated = true
 				}
+			} else if resp.Action == "delete" || resp.Action == "expire" {
+				// If the Action is either "delete" or "expire" delete the entry
+				// from the local services map. This indicates that the service
+				// instance has exited or died.
+				delete(services, resp.Node.Key)
+				updated = true
 			}
 
-			// if anything has changed then send the new pairs to the caller.
+			// If anything has changed then send the new pairs to the caller.
 			if updated == true {
-				tracker <- TrackerData{Pairs: curKeyVals, Err: nil}
+				tracker <- ServiceData{Services: services, Err: nil}
 			}
 		}
 
 		// If the observer channel is closed then close the tracker channel too.
 		close(tracker)
+		tracker = nil
 
 		// Adjust the WaitGroup counter before exiting the go-routine.
-		st.wg.Done()
+		t.wg.Done()
 	}()
 
 	return tracker, nil
 }
 
 // Description:
-//     A routine to stop the service tracking openation.
+//     A routine to stop the service tracking operation.
 //
 // Parameters:
 //     None
 //
 // Return value:
 //     None
-func (st *ServiceTracker) Stop() {
-	st.obsvr.Stop()
-	st.wg.Wait()
+func (t *tracker) Stop() {
+	t.obsvr.Stop()
+	t.wg.Wait()
 }


### PR DESCRIPTION
The following are the changes:
[1] Whenever a change is seen during a watch, etcd indicates
    what was the kind of change in the 'Action' field of the
    'Response' object. The 'Action' field is being now used to
    efficiently update the list of services.
[2] Renamed the outward channel type to ServiceData from TrackerData.
    Also the ServiceData now contains a map of all the services
    present instead of a list of key-value pairs.
[3] Changed ServiceTracker to be an interface and introduced a
    notion of tracker to adhere to the interface.
