### PR TITLE
Use the go context contructs instead of the one used in etcd.

### DIFF
--- a/Go/ephemeral_key.go
+++ b/Go/ephemeral_key.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 )
 
 // EPHEMERAL-KEY RECIPE

--- a/Go/leader_elector.go
+++ b/Go/leader_elector.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 )
 
 // LEADER-ELECTOR RECIPE

--- a/Go/observer.go
+++ b/Go/observer.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 )
 
 // OBSERVER RECIPE


### PR DESCRIPTION
Initially we were relying on the context construct that was available
within the etcd godeps directory. As it is a maintenance problem
it would be better to use the vanila context construct.
